### PR TITLE
fix breaking of stroke when mouse movement is fast

### DIFF
--- a/sketch/index.html
+++ b/sketch/index.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0px">
  <canvas id="box" width="1000px" height="1000px" style="border-width: 1px;background-color: aquamarine;border-style: double"
-onmousedown="col()" onmouseup="cool()">
+onmousedown="col(this)" onmouseup="cool(this)">
 
 </canvas>
  </body>

--- a/sketch/sketch.js
+++ b/sketch/sketch.js
@@ -1,28 +1,40 @@
  var flag=0;
+var canvas = document.getElementById('box');
+const rect = canvas.getBoundingClientRect();
+let prevPos = {
+  x : 0,
+  y : 0
+}
 
 function getMousePos(canvas, evt) {
-    var rect = canvas.getBoundingClientRect();
     return {
         x: evt.clientX - rect.left,
         y: evt.clientY - rect.top
     };
 }
-var canvas = document.getElementById('box');
+
 var context = canvas.getContext('2d');
  canvas.addEventListener('mousemove', function(evt) {
-     if (flag)
-     {       var mousePos = getMousePos(canvas, evt);
-     console.log(mousePos.x, mousePos.y);
-         context.rect(mousePos.x,mousePos.y,2,2)
+    setTimeout( function () {
+      if (flag)
+     {   
+         var mousePos = getMousePos(canvas, evt);
          context.fillStyle="blue";
-         context.fill();
- }
+         context.beginPath();
+         context.moveTo(mousePos.x,mousePos.y);
+         context.lineTo(prevPos.x,prevPos.y);
+         context.stroke();
+         prevPos = mousePos;
+      }
+    } , 0 );   // defer the 
+   
 }, false);
 
 cool=function () {
     flag=0;
 }
-col=function () {
+col=function (evt) {
+  prevPos = getMousePos(canvas,evt);
     flag=1;
 
 }


### PR DESCRIPTION
When the movement of mouse is too fast, the browser cannot throw event handler at the same rate. Thus we draw a line from previous known mouse position to current.